### PR TITLE
feat: expose FHIR version from the generated FHIRPath model

### DIFF
--- a/internal/codegen/generator/codegen.go
+++ b/internal/codegen/generator/codegen.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode/utf8"
 
@@ -32,6 +33,7 @@ type CodeGen struct {
 	valueSets    *parser.ValueSetRegistry
 	usedBindings map[string]bool               // Track which bindings are actually used
 	rawSDs       []*parser.StructureDefinition // All SDs before filtering, used for hierarchy
+	fhirVersion  string                        // FHIR release of the loaded specs, e.g. "4.0.1"
 }
 
 // New creates a new CodeGen instance.
@@ -88,6 +90,14 @@ func (c *CodeGen) LoadTypes() error {
 	}
 	c.rawSDs = append(c.rawSDs, rawTypeSDs...)
 	c.rawSDs = append(c.rawSDs, rawResourceSDs...)
+
+	// Derive the FHIR release from the specs themselves, so generated code never
+	// carries a hand-written version string.
+	fhirVersion, err := detectFHIRVersion(c.rawSDs)
+	if err != nil {
+		return fmt.Errorf("failed to determine FHIR version from %s: %w", specsDir, err)
+	}
+	c.fhirVersion = fhirVersion
 
 	// Create ONE analyzer with ALL definitions and value sets
 	c.analyzer = analyzer.NewAnalyzer(allSDs, c.valueSets)
@@ -168,6 +178,46 @@ func (c *CodeGen) loadStructureDefinitions(path string) ([]*parser.StructureDefi
 	}
 
 	return filtered, nil
+}
+
+// detectFHIRVersion derives the FHIR release (e.g. "4.0.1") from the
+// StructureDefinitions being generated from, so that generated code never
+// carries a hand-written version string.
+//
+// Definitions without a fhirVersion are ignored. Disagreement is fatal: a model
+// that cannot state its version unambiguously must not be emitted.
+func detectFHIRVersion(sds []*parser.StructureDefinition) (string, error) {
+	// Track one example definition per distinct value to make conflicts diagnosable.
+	examples := make(map[string]string)
+	for _, sd := range sds {
+		if sd.FHIRVersion == "" {
+			continue
+		}
+		if _, seen := examples[sd.FHIRVersion]; !seen {
+			examples[sd.FHIRVersion] = sd.Name
+		}
+	}
+
+	switch len(examples) {
+	case 1:
+		for version := range examples {
+			return version, nil
+		}
+	case 0:
+		return "", fmt.Errorf("no StructureDefinition declares a fhirVersion (checked %d definitions)", len(sds))
+	}
+
+	versions := make([]string, 0, len(examples))
+	for version := range examples {
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+
+	conflicts := make([]string, 0, len(versions))
+	for _, version := range versions {
+		conflicts = append(conflicts, fmt.Sprintf("%s (e.g. %s)", version, examples[version]))
+	}
+	return "", fmt.Errorf("StructureDefinitions declare conflicting fhirVersion values: %s", strings.Join(conflicts, ", "))
 }
 
 // Generate writes all generated code to the output directory.

--- a/internal/codegen/generator/codegen_test.go
+++ b/internal/codegen/generator/codegen_test.go
@@ -1,0 +1,97 @@
+package generator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gofhir/models/internal/codegen/parser"
+)
+
+func TestDetectFHIRVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		sds     []*parser.StructureDefinition
+		want    string
+		wantErr string
+	}{
+		{
+			name: "single version across definitions",
+			sds: []*parser.StructureDefinition{
+				{Name: "Patient", FHIRVersion: "4.0.1"},
+				{Name: "Observation", FHIRVersion: "4.0.1"},
+			},
+			want: "4.0.1",
+		},
+		{
+			name: "definitions without a fhirVersion are ignored",
+			sds: []*parser.StructureDefinition{
+				{Name: "Patient", FHIRVersion: "5.0.0"},
+				{Name: "SomeLogicalModel"},
+			},
+			want: "5.0.0",
+		},
+		{
+			name: "version is not inferred from the artifact version",
+			sds: []*parser.StructureDefinition{
+				{Name: "Patient", Version: "4.0.1"},
+			},
+			wantErr: "no StructureDefinition declares a fhirVersion",
+		},
+		{
+			name:    "no definitions",
+			sds:     nil,
+			wantErr: "no StructureDefinition declares a fhirVersion",
+		},
+		{
+			name: "conflicting versions are fatal",
+			sds: []*parser.StructureDefinition{
+				{Name: "Patient", FHIRVersion: "4.0.1"},
+				{Name: "Observation", FHIRVersion: "5.0.0"},
+			},
+			wantErr: "conflicting fhirVersion values: 4.0.1 (e.g. Patient), 5.0.0 (e.g. Observation)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := detectFHIRVersion(tt.sds)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got version %q", tt.wantErr, got)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+// The conflict message lists versions in a stable order regardless of input order,
+// so generation failures are reproducible.
+func TestDetectFHIRVersion_ConflictMessageIsDeterministic(t *testing.T) {
+	_, first := detectFHIRVersion([]*parser.StructureDefinition{
+		{Name: "Patient", FHIRVersion: "4.0.1"},
+		{Name: "Observation", FHIRVersion: "5.0.0"},
+	})
+	_, reversed := detectFHIRVersion([]*parser.StructureDefinition{
+		{Name: "Observation", FHIRVersion: "5.0.0"},
+		{Name: "Patient", FHIRVersion: "4.0.1"},
+	})
+
+	if first == nil || reversed == nil {
+		t.Fatal("expected both inputs to conflict")
+	}
+	if first.Error() != reversed.Error() {
+		t.Errorf("message depends on input order:\n  %s\n  %s", first.Error(), reversed.Error())
+	}
+}

--- a/internal/codegen/generator/fhirpath_codegen.go
+++ b/internal/codegen/generator/fhirpath_codegen.go
@@ -11,6 +11,7 @@ import (
 // FHIRPathModelTemplateData holds all data needed by fhirpath_model.go.tmpl.
 type FHIRPathModelTemplateData struct {
 	TemplateData
+	FHIRVersion           string
 	ChoiceTypePaths       []FHIRPathKVMulti
 	Path2Type             []FHIRPathKV
 	Path2RefType          []FHIRPathKVMulti
@@ -100,6 +101,7 @@ func (c *CodeGen) generateFHIRPathModel() error {
 			Version:     strings.ToUpper(c.config.Version),
 			FileType:    "fhirpath_model",
 		},
+		FHIRVersion:           c.fhirVersion,
 		ChoiceTypePaths:       sortedKVMulti(choiceTypeMap),
 		Path2Type:             sortedKV(path2TypeMap),
 		Path2RefType:          sortedKVMulti(path2RefMap),

--- a/internal/codegen/generator/templates/fhirpath_model.go.tmpl
+++ b/internal/codegen/generator/templates/fhirpath_model.go.tmpl
@@ -11,6 +11,7 @@ package {{.PackageName}}
 //
 // Use [FHIRPathModel] to obtain the singleton for this package.
 type FHIRPathModelData struct {
+	fhirVersion           string
 	choiceTypePaths       map[string][]string
 	path2Type             map[string]string
 	path2RefType          map[string][]string
@@ -21,6 +22,10 @@ type FHIRPathModelData struct {
 
 // fhirpathModel is the package-level singleton populated at init time.
 var fhirpathModel = FHIRPathModelData{
+
+	// fhirVersion is the FHIR release these definitions were generated from,
+	// taken from StructureDefinition.fhirVersion in the source spec bundle.
+	fhirVersion: "{{.FHIRVersion}}",
 
 	// choiceTypePaths maps the base path of a polymorphic element (without the type suffix)
 	// to the ordered list of permitted type codes.
@@ -78,6 +83,16 @@ var fhirpathModel = FHIRPathModelData{
 // FHIRPathModel returns the FHIRPath metadata singleton for this FHIR version.
 func FHIRPathModel() *FHIRPathModelData {
 	return &fhirpathModel
+}
+
+// FHIRVersion returns the FHIR release this model describes, e.g. "4.0.1".
+//
+// It identifies the static model compiled into the binary, which is what lets a
+// version-aware consumer reconcile it against StructureDefinitions loaded at
+// runtime, or key a registry of models by version without maintaining a
+// separate package-to-version table.
+func (m *FHIRPathModelData) FHIRVersion() string {
+	return m.fhirVersion
 }
 
 // ChoiceTypes returns the permitted type codes for a polymorphic element path.

--- a/internal/codegen/parser/structuredefinition.go
+++ b/internal/codegen/parser/structuredefinition.go
@@ -12,10 +12,15 @@ import (
 // StructureDefinition represents a FHIR StructureDefinition resource.
 // This is a simplified version containing only the fields needed for code generation.
 type StructureDefinition struct {
-	ResourceType   string        `json:"resourceType"`
-	ID             string        `json:"id"`
-	URL            string        `json:"url"`
-	Version        string        `json:"version"`
+	ResourceType string `json:"resourceType"`
+	ID           string `json:"id"`
+	URL          string `json:"url"`
+	// Version is the version of this artifact, not of FHIR itself.
+	Version string `json:"version"`
+	// FHIRVersion is the FHIR release this definition is written against
+	// (e.g. "4.0.1"). Distinct from Version, even though core spec bundles
+	// happen to set both to the same value.
+	FHIRVersion    string        `json:"fhirVersion"`
 	Name           string        `json:"name"`
 	Title          string        `json:"title"`
 	Status         string        `json:"status"`

--- a/r4/fhirpath_model.go
+++ b/r4/fhirpath_model.go
@@ -10,6 +10,7 @@ package r4
 //
 // Use [FHIRPathModel] to obtain the singleton for this package.
 type FHIRPathModelData struct {
+	fhirVersion           string
 	choiceTypePaths       map[string][]string
 	path2Type             map[string]string
 	path2RefType          map[string][]string
@@ -20,6 +21,10 @@ type FHIRPathModelData struct {
 
 // fhirpathModel is the package-level singleton populated at init time.
 var fhirpathModel = FHIRPathModelData{
+
+	// fhirVersion is the FHIR release these definitions were generated from,
+	// taken from StructureDefinition.fhirVersion in the source spec bundle.
+	fhirVersion: "4.0.1",
 
 	// choiceTypePaths maps the base path of a polymorphic element (without the type suffix)
 	// to the ordered list of permitted type codes.
@@ -9563,6 +9568,16 @@ var fhirpathModel = FHIRPathModelData{
 // FHIRPathModel returns the FHIRPath metadata singleton for this FHIR version.
 func FHIRPathModel() *FHIRPathModelData {
 	return &fhirpathModel
+}
+
+// FHIRVersion returns the FHIR release this model describes, e.g. "4.0.1".
+//
+// It identifies the static model compiled into the binary, which is what lets a
+// version-aware consumer reconcile it against StructureDefinitions loaded at
+// runtime, or key a registry of models by version without maintaining a
+// separate package-to-version table.
+func (m *FHIRPathModelData) FHIRVersion() string {
+	return m.fhirVersion
 }
 
 // ChoiceTypes returns the permitted type codes for a polymorphic element path.

--- a/r4/fhirpath_model_test.go
+++ b/r4/fhirpath_model_test.go
@@ -12,6 +12,11 @@ func TestFHIRPathModel_NotNil(t *testing.T) {
 	require.NotNil(t, m)
 }
 
+func TestFHIRPathModel_FHIRVersion(t *testing.T) {
+	// Must match StructureDefinition.fhirVersion in specs/r4, not the package name.
+	assert.Equal(t, "4.0.1", FHIRPathModel().FHIRVersion())
+}
+
 func TestFHIRPathModel_ChoiceTypes(t *testing.T) {
 	m := FHIRPathModel()
 

--- a/r4b/fhirpath_model.go
+++ b/r4b/fhirpath_model.go
@@ -10,6 +10,7 @@ package r4b
 //
 // Use [FHIRPathModel] to obtain the singleton for this package.
 type FHIRPathModelData struct {
+	fhirVersion           string
 	choiceTypePaths       map[string][]string
 	path2Type             map[string]string
 	path2RefType          map[string][]string
@@ -20,6 +21,10 @@ type FHIRPathModelData struct {
 
 // fhirpathModel is the package-level singleton populated at init time.
 var fhirpathModel = FHIRPathModelData{
+
+	// fhirVersion is the FHIR release these definitions were generated from,
+	// taken from StructureDefinition.fhirVersion in the source spec bundle.
+	fhirVersion: "4.3.0",
 
 	// choiceTypePaths maps the base path of a polymorphic element (without the type suffix)
 	// to the ordered list of permitted type codes.
@@ -9687,6 +9692,16 @@ var fhirpathModel = FHIRPathModelData{
 // FHIRPathModel returns the FHIRPath metadata singleton for this FHIR version.
 func FHIRPathModel() *FHIRPathModelData {
 	return &fhirpathModel
+}
+
+// FHIRVersion returns the FHIR release this model describes, e.g. "4.0.1".
+//
+// It identifies the static model compiled into the binary, which is what lets a
+// version-aware consumer reconcile it against StructureDefinitions loaded at
+// runtime, or key a registry of models by version without maintaining a
+// separate package-to-version table.
+func (m *FHIRPathModelData) FHIRVersion() string {
+	return m.fhirVersion
 }
 
 // ChoiceTypes returns the permitted type codes for a polymorphic element path.

--- a/r4b/fhirpath_model_test.go
+++ b/r4b/fhirpath_model_test.go
@@ -1,0 +1,17 @@
+package r4b
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFHIRPathModel_NotNil(t *testing.T) {
+	require.NotNil(t, FHIRPathModel())
+}
+
+func TestFHIRPathModel_FHIRVersion(t *testing.T) {
+	// Must match StructureDefinition.fhirVersion in specs/r4b, not the package name.
+	assert.Equal(t, "4.3.0", FHIRPathModel().FHIRVersion())
+}

--- a/r5/fhirpath_model.go
+++ b/r5/fhirpath_model.go
@@ -10,6 +10,7 @@ package r5
 //
 // Use [FHIRPathModel] to obtain the singleton for this package.
 type FHIRPathModelData struct {
+	fhirVersion           string
 	choiceTypePaths       map[string][]string
 	path2Type             map[string]string
 	path2RefType          map[string][]string
@@ -20,6 +21,10 @@ type FHIRPathModelData struct {
 
 // fhirpathModel is the package-level singleton populated at init time.
 var fhirpathModel = FHIRPathModelData{
+
+	// fhirVersion is the FHIR release these definitions were generated from,
+	// taken from StructureDefinition.fhirVersion in the source spec bundle.
+	fhirVersion: "5.0.0",
 
 	// choiceTypePaths maps the base path of a polymorphic element (without the type suffix)
 	// to the ordered list of permitted type codes.
@@ -11863,6 +11868,16 @@ var fhirpathModel = FHIRPathModelData{
 // FHIRPathModel returns the FHIRPath metadata singleton for this FHIR version.
 func FHIRPathModel() *FHIRPathModelData {
 	return &fhirpathModel
+}
+
+// FHIRVersion returns the FHIR release this model describes, e.g. "4.0.1".
+//
+// It identifies the static model compiled into the binary, which is what lets a
+// version-aware consumer reconcile it against StructureDefinitions loaded at
+// runtime, or key a registry of models by version without maintaining a
+// separate package-to-version table.
+func (m *FHIRPathModelData) FHIRVersion() string {
+	return m.fhirVersion
 }
 
 // ChoiceTypes returns the permitted type codes for a polymorphic element path.

--- a/r5/fhirpath_model_test.go
+++ b/r5/fhirpath_model_test.go
@@ -1,0 +1,17 @@
+package r5
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFHIRPathModel_NotNil(t *testing.T) {
+	require.NotNil(t, FHIRPathModel())
+}
+
+func TestFHIRPathModel_FHIRVersion(t *testing.T) {
+	// Must match StructureDefinition.fhirVersion in specs/r5, not the package name.
+	assert.Equal(t, "5.0.0", FHIRPathModel().FHIRVersion())
+}


### PR DESCRIPTION
Closes #10.

Adds `FHIRVersion()` to the generated FHIRPath model, derived from the spec bundle rather than written by hand.

## Changes

**Parser** — `StructureDefinition` now captures `fhirVersion`. It was already parsing `version`, which is the artifact version; the core bundles happen to set both to the same value, but they are different fields and only `fhirVersion` answers "which FHIR release is this written against".

**Generator** — `detectFHIRVersion()` derives the release from the unfiltered `rawSDs` already loaded for the type hierarchy. Definitions without the field are ignored (`OperationDefinition`/`CompartmentDefinition` entries in `profiles-resources.json` never reach it anyway). Disagreement is fatal and reported with an example definition per value:

```
failed to determine FHIR version from specs/r4: StructureDefinitions declare
conflicting fhirVersion values: 4.0.1 (e.g. Patient), 5.0.0 (e.g. Observation)
```

It runs in `LoadTypes`, so a bad spec set fails before any file is written.

**Template** — `fhirVersion` field on the struct plus the accessor.

## Generated output

`4.0.1` / `4.3.0` / `5.0.0`. The diff is +15 lines per package and nothing else moved — the rest of each model is byte-identical to the previous generation.

## Why not derive it from `Config.Version`

That field holds `"r4" | "r4b" | "r5"`. A `switch` mapping it to `"4.0.1"` would satisfy "not hand-written per release" while still being a hand-maintained table, just relocated into the generator. The point of the acceptance criterion is that nobody maintains the mapping at all.

## Tests

- `internal/codegen/generator/codegen_test.go` — single version, definitions missing the field, conflict, empty input, deterministic conflict message, and the case that pins the acceptance criterion: a definition carrying `version: "4.0.1"` but no `fhirVersion` yields an error, not a version.
- `FHIRVersion` asserted in all three packages. `r4b` and `r5` had no `fhirpath_model_test.go`; they do now.

```
ok  r4  ok  r4b  ok  r5
ok  analyzer  ok  parser  ok  generator
go vet clean, gofmt clean
```

## Note for a follow-up

`terminology_codegen.go` takes `fhirVersion string` as a parameter and has its own `versionToSuffix`, but has no callers in the repo. If that path is ever activated it should consume the detected value instead of receiving the string from outside, so there is one source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
